### PR TITLE
Adding multithreaded flag to disable unusedFunction checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,11 @@ jobs:
       - run: 
           name: Test json
           working_directory: ~/codacy-plugins-test
-          command: sbt -Dcodacy.tests.ignore.descriptions=true "run-main codacy.plugins.DockerTest json codacy/$CIRCLE_PROJECT_REPONAME:latest"
+          command: sbt -Dcodacy.tests.ignore.descriptions=true "runMain codacy.plugins.DockerTest json codacy/$CIRCLE_PROJECT_REPONAME:latest"
       - run:
           name: Test patterns
           working_directory: ~/codacy-plugins-test
-          command: sbt -Dcodacy.tests.noremove=true -Dcodacy.tests.threads=8 "run-main codacy.plugins.DockerTest pattern codacy/$CIRCLE_PROJECT_REPONAME:latest"
+          command: sbt -Dcodacy.tests.noremove=true -Dcodacy.tests.threads=8 "runMain codacy.plugins.DockerTest pattern codacy/$CIRCLE_PROJECT_REPONAME:latest"
       - deploy:
           name: Push application Docker image
           command: |

--- a/src/main/scala/codacy/cppcheck/CPPCheck.scala
+++ b/src/main/scala/codacy/cppcheck/CPPCheck.scala
@@ -39,7 +39,7 @@ object CPPCheck extends Tool {
           }
         }.getOrElse("")
 
-      val command = List("cppcheck", "--enable=all", "--error-exitcode=0", "--force", languageParameter,
+      val command = List("cppcheck", "--enable=all", "--error-exitcode=0", "--force", "-j 2", languageParameter,
         """--template={"patternId":"{id}","file":"{file}","line":"{line}","message":"{message}"}""") ++
         filesToLint
 


### PR DESCRIPTION
This is mainly needed to enforce disabling unusedFunction checking.

As the flag enable=all is being passed, and this tool doesn't allow disabling only the unusedFunction only, this is a way to enforce as per cppcheck documnentation.