### PR TITLE
bump: Bump base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM alpine:3.13.6
+FROM alpine:3.17.2
 
 ARG toolVersion=2.10
 


### PR DESCRIPTION
I was having some errors when running `docker build` locally (Please note that I am on an M1 MacBook). Bumping the base image fixed the issue.

Below are the errors I observed:
<img width="943" alt="Screenshot 2023-02-28 at 12 43 13" src="https://user-images.githubusercontent.com/50848406/221877544-479f96b1-2774-4605-a716-772ebea97966.png">
