### PR TITLE
bump: Update cppcheck version to 2.10.3 IO-541

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@10.1.1
+  codacy: codacy/base@10.6.0
   codacy_plugins_test: codacy/plugins-test@1.1.1
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # dev is just used for development purposes. Not used for production images
 FROM codacy-cppcheck-base as dev
 
-RUN apk add openjdk11	
+RUN apk add openjdk17
 COPY docs /docs	
 COPY addons/misra* /workdir/addons/	
 RUN adduser --uid 2004 --disabled-password --gecos "" docker	

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM alpine:3.17.2
 
-ARG toolVersion=2.10
+ARG toolVersion=2.10.3
 
 RUN \
     # runtime packages

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name" : "cppcheck",
-  "version" : "2.10",
+  "version" : "2.10.3",
   "patterns" : [ {
     "patternId" : "purgedConfiguration",
     "level" : "Info",


### PR DESCRIPTION
Bumping `cppcheck` to a more recent version.
Also bumping the base image to version 10.6.0 and using `openjdk17`.