### PR TITLE
Clean/cppcheck improvements

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0
+sbt.version=1.8.3


### PR DESCRIPTION
Trying to clean cppcheck in an attempt to remove the warning logs we were finding. See an example below.
```
KubernetesDockerRunner: Container for codacy/codacy-cppcheck:2.10.8 exited with non-zero code 2
Jun 01, 2023 1:42:38 PM com.fasterxml.jackson.databind.ext.Java7Support <clinit>
WARNING: Unable to load JDK7 types (annotations, java.nio.file.Path): no Java7 support added
```